### PR TITLE
sslhelper: support openssl 3.0

### DIFF
--- a/sslhelper.c
+++ b/sslhelper.c
@@ -181,7 +181,11 @@ int ExtractQxQyFromPubkey(const char *file, unsigned char **qx,
     int i, j;
     unsigned char *pub;
     int publen;
+#if (OPENSSL_VERSION_NUMBER < 0x30000000L)
     EC_KEY *eckey = NULL;
+#else
+    EVP_PKEY *eckey = NULL;
+#endif
     // check for any NULLs
     if (file == NULL)
     {
@@ -196,6 +200,7 @@ int ExtractQxQyFromPubkey(const char *file, unsigned char **qx,
             fprintf(stderr, "%sFailed to read eckey %s.\n", getErr(), file);
             ret = 0;
         }
+#if (OPENSSL_VERSION_NUMBER < 0x30000000L)
         if (ret)
         {
             eckey = PEM_read_bio_EC_PUBKEY(in, NULL, NULL, NULL);
@@ -209,6 +214,21 @@ int ExtractQxQyFromPubkey(const char *file, unsigned char **qx,
         {
             publen =
                 EC_KEY_key2buf(eckey, EC_KEY_get_conv_form(eckey), &pub, NULL);
+#else
+        if (ret)
+        {
+            eckey = PEM_read_bio_PUBKEY(in, NULL, NULL, NULL);
+        }
+        if (eckey == NULL && ret)
+        {
+            fprintf(stderr, "%sFailed to read eckey %s.\n", getErr(), file);
+            ret = 0;
+        }
+        if (ret)
+        {
+            publen =
+                EVP_PKEY_get1_encoded_public_key(eckey, &pub);
+#endif
             if (pub[0] != 0x04)
             {
                 // key is compressed, we don't support this


### PR DESCRIPTION
The functions currently used in the sslhelper.c are deprecated in openssl 3.0,
but the APIs necessary for conversion also do not exist in 1.1.
Add a #define on the OPENSSL_VERSION_NUMBER to identify 3.x (or greater)
support and switch between the two API sets.

Error Log:
```
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c: In function ‘ExtractQxQyFromPubkey’:
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:201:13: warning: ‘PEM_read_bio_EC_PUBKEY’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
             eckey = PEM_read_bio_EC_PUBKEY(in, NULL, NULL, NULL);
             ^~~~~
In file included from /home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:23:0:
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/pem.h:70:11: note: declared here
     type *PEM_##readname##_##name(INTYPE *out, type **x,                \
           ^
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/pem.h:268:10: note: in expansion of macro ‘PEM_read_cb_fnsig’
     attr PEM_read_cb_fnsig(name, type, BIO, read_bio);
          ^~~~~~~~~~~~~~~~~
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/pem.h:332:5: note: in expansion of macro ‘DECLARE_PEM_read_bio_attr’
     DECLARE_PEM_read_bio_attr(attr, name, type)                             \
     ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/pem.h:342:5: note: in expansion of macro ‘DECLARE_PEM_read_attr’
     DECLARE_PEM_read_attr(attr, name, type)                                 \
     ^~~~~~~~~~~~~~~~~~~~~
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/pem.h:463:1: note: in expansion of macro ‘DECLARE_PEM_rw_attr’
 DECLARE_PEM_rw_attr(OSSL_DEPRECATEDIN_3_0, EC_PUBKEY, EC_KEY)
 ^~~~~~~~~~~~~~~~~~~
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:211:17: warning: ‘EC_KEY_key2buf’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
                 EC_KEY_key2buf(eckey, EC_KEY_get_conv_form(eckey), &pub, NULL);
                 ^~~~~~~~~~~~~~
In file included from /home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:20:0:
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/ec.h:1133:30: note: declared here
 OSSL_DEPRECATEDIN_3_0 size_t EC_KEY_key2buf(const EC_KEY *key,
                              ^~~~~~~~~~~~~~
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:211:17: warning: ‘EC_KEY_get_conv_form’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
                 EC_KEY_key2buf(eckey, EC_KEY_get_conv_form(eckey), &pub, NULL);
                 ^~~~~~~~~~~~~~
In file included from /home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:20:0:
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/ec.h:1074:47: note: declared here
 OSSL_DEPRECATEDIN_3_0 point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key);
                                               ^~~~~~~~~~~~~~~~~~~~
In file included from /home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/evp.h:30:0,
                 from /home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.h:17,
                 from /home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:16:
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c: In function ‘VerifyData’:
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/../openssl-openssl-3.0.3/include/openssl/bio.h:555:34: warning: value computed is not used [-Wunused-value]
 # define BIO_reset(b)            (int)BIO_ctrl(b,BIO_CTRL_RESET,0,NULL)
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jamin/debug/openssl-debug/intel-pfr-signing-utility/sslhelper.c:627:13: note: in expansion of macro ‘BIO_reset’
             BIO_reset(pkeyBio);
             ^~~~~~~~~
```

Signed-off-by: Jamin Lin <jamin_lin@aspeedtech.com>

